### PR TITLE
Allow Get-GitRoot to work with worktrees

### DIFF
--- a/src/Features/Git.Autoload.psm1
+++ b/src/Features/Git.Autoload.psm1
@@ -8,18 +8,29 @@ function Set-GitRoot()
 
 function Get-GitRoot()
 {
-    $currentDirectory = Convert-Path .
-    $lastIndex = $currentDirectory.LastIndexOf('\')
-
-    while ($lastIndex -ne -1)
+    if (Get-Command git 2>$null)
     {
-        if (Test-Path (Join-Path $currentDirectory ".git") -PathType Container)
+        $root =  . git rev-parse --show-toplevel 2>$null
+        if ($LASTEXITCODE -eq 0)
         {
-            return $currentDirectory
+            return Convert-Path $root
         }
-
-        $currentDirectory = $currentDirectory.Substring(0, $lastIndex)
+    }
+    else
+    {
+        $currentDirectory = Convert-Path .
         $lastIndex = $currentDirectory.LastIndexOf('\')
+
+        while ($lastIndex -ne -1)
+        {
+            if (Test-Path (Join-Path $currentDirectory ".git") -PathType Container)
+            {
+                return $currentDirectory
+            }
+
+            $currentDirectory = $currentDirectory.Substring(0, $lastIndex)
+            $lastIndex = $currentDirectory.LastIndexOf('\')
+        }
     }
 
     Write-Host -ForegroundColor Yellow "Not a git repository"


### PR DESCRIPTION
Worktrees don't have a `.git` directory.

Fixes https://github.com/gundermanc/tools/issues/65.