### PR TITLE
Fix ptapply to work in PowerShell 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Aliases for launching Visual Studio installs developer command prompts.
 - vspatch [instance]: Selects an instance of VS as the target application for patching or running Apex tests.
 
 ## ChangeLog
+- 2/11/2025 - Accepted contribution to fix pathing when using PowerShell 7
 - 9/18/2023 - Accepted contribution to make Get-GitRoot work with Git worktrees.
 - 10/2/2020 - Added 'sudo' alias.
 - 2/26/2020 - Fixed installation failure if 'ToolsScratch' doesn't exist.

--- a/src/Common/Config.psm1
+++ b/src/Common/Config.psm1
@@ -16,7 +16,7 @@ $ConfigurationValues =
     "DisableConsole" = $true
     "InstallationPath" = New-InstallationPath
     "IsInstalled" = $false
-    "Version" = "0.76"
+    "Version" = "0.77"
 }
 
 $RegistryRootKeyPath = "HKCU:Software\Tools"

--- a/src/Features/Patch.Autoload.psm1
+++ b/src/Features/Patch.Autoload.psm1
@@ -187,6 +187,9 @@ function CheckAssemblyVersions($source, $destination)
 
     Write-Host "  - Checking that assembly versions match..."
 
+    # Windows PowerShell and PowerShell 7 have different executables
+    # with Windows PowerShell using powershell.exe and 7 using pwsh.exe.
+    # Check the current major version to see if we're using the new version.
     if ($PSVersionTable.PSVersion.Major -ge 6) {
         $powershellPath = (Join-Path $PsHome "pwsh.exe")
     } else {

--- a/src/Features/Patch.Autoload.psm1
+++ b/src/Features/Patch.Autoload.psm1
@@ -187,7 +187,11 @@ function CheckAssemblyVersions($source, $destination)
 
     Write-Host "  - Checking that assembly versions match..."
 
-    $powershellPath = (Join-Path $PsHome "powershell.exe")
+    if ($PSVersionTable.PSVersion.Major -ge 6) {
+        $powershellPath = (Join-Path $PsHome "pwsh.exe")
+    } else {
+        $powershellPath = (Join-Path $PsHome "powershell.exe")
+    }
 
     # Load assemblies in separate process and check their versions to make sure
     # they match. This is done in a separate process so that the assemblies are


### PR DESCRIPTION
Fixes #67

Update `src/Features/Patch.Autoload.psm1` to support PowerShell 7.

* Add a check to determine if running in PowerShell 7 by checking `$PSVersionTable.PSVersion.Major`.
* Update the `$powershellPath` variable to use `pwsh.exe` if running in PowerShell 7, otherwise use `powershell.exe`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gundermanc/tools/pull/68?shareId=54ebf926-48d4-40fd-afcc-9f9e693b55d7).